### PR TITLE
far[12] - make rails_helper required in RSpec instead of spec_helper

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---require spec_helper
+--require rails_helper


### PR DESCRIPTION
far[12] - make rails_helper required in RSpec instead of spec_helper