### PR TITLE
far[17] - replace standard Rails error page in development with Better-Errors and BindingOfCaller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ group :test do
 end
 
 group :development, :test do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'pry', '~> 0.13.1'
   gem 'rspec-rails', '~> 5.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,12 +56,19 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    better_errors (2.9.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     factory_bot (6.2.0)
@@ -177,6 +184,8 @@ PLATFORMS
   arm64-darwin-20
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bootsnap (>= 1.4.2)
   factory_bot_rails
   listen (~> 3.2)


### PR DESCRIPTION
far[17] - replace standard Rails error page in development with Better-Errors and BindingOfCaller