### PR TITLE
far[24] - add LicenseFinder config & initializer, allowed: MIT, Apache2, GPL2.0+/3.0+, Simplified/New BSD, Artistic-2, Brakeman Public

### DIFF
--- a/config/allowed_licenses.yml
+++ b/config/allowed_licenses.yml
@@ -1,0 +1,32 @@
+---
+- - :permit
+  - MIT
+  - &1
+    :who:
+    :why:
+    :versions: []
+    :when: 2021-12-12 23:58:32.994637000 Z
+- - :permit
+  - Apache 2.0
+  - *1
+- - :permit
+  - Simplified BSD
+  - *1
+- - :permit
+  - Simplified BSD, ruby
+  - *1
+- - :permit
+  - Apache 2.0, MIT
+  - *1
+- - :permit
+  - New BSD
+  - *1
+- - :permit
+  - Artistic-2.0, GPL-2.0+, MIT
+  - *1
+- - :permit
+  - Brakeman Public Use License
+  - *1
+- - :permit
+  - GPL-3.0+
+  - *1

--- a/config/license_finder.yml
+++ b/config/license_finder.yml
@@ -1,0 +1,4 @@
+---
+decisions_file: 'config/allowed_licenses.yml'
+enabled_package_managers:
+  - bundler


### PR DESCRIPTION
far[24] - add LicenseFinder config & initializer, allowed: MIT, Apache2, GPL2.0+/3.0+, Simplified/New BSD, Artistic-2, Brakeman Public