### PR TITLE
far[25] - add support for x86_64-linux platform to Bundle lockfile for Docker CI runs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     parslet (1.8.2)
     pg (1.2.3)
     pry (0.13.1)
@@ -172,6 +174,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   actionmailbox (= 6.0.4.1)


### PR DESCRIPTION
far[25] - add support for x86_64-linux platform to Bundle lockfile for Docker CI runs
`bundle lock --add-platform x86_64-linux`